### PR TITLE
🔒 Use correct identity for terminating ProcessInstances manually

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -269,6 +269,7 @@ pipeline {
       }
     }
     stage('Check test results') {
+      options {skipDefaultCheckout()}
       steps {
         script {
           if (sqlite_tests_failed || postgres_test_failed || mysql_test_failed) {
@@ -291,6 +292,7 @@ pipeline {
       }
     }
     stage('Send Test Results to Slack') {
+      options {skipDefaultCheckout()}
       steps {
         script {
           // Failure to send the slack message should not result in build failure.
@@ -311,6 +313,7 @@ pipeline {
       }
     }
     stage('Cleanup') {
+      options {skipDefaultCheckout()}
       steps {
         script {
           // This stage just exists, so the cleanup work that happens

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -35,7 +35,7 @@
     "@process-engine/iam": "~1.7.1",
     "@process-engine/logging_api_core": "~2.0.0",
     "@process-engine/logging.repository.file_system": "~2.0.0",
-    "@process-engine/process_engine_core": "feature~fix_identity_usage_upon_process_termination",
+    "@process-engine/process_engine_core": "12.13.0-alpha.1",
     "@process-engine/persistence_api.repositories.sequelize": "~1.1.0",
     "@process-engine/persistence_api.services": "~1.1.0",
     "@process-engine/persistence_api.use_cases": "~1.1.0",

--- a/_integration_tests/package.json
+++ b/_integration_tests/package.json
@@ -35,7 +35,7 @@
     "@process-engine/iam": "~1.7.1",
     "@process-engine/logging_api_core": "~2.0.0",
     "@process-engine/logging.repository.file_system": "~2.0.0",
-    "@process-engine/process_engine_core": "~12.12.0",
+    "@process-engine/process_engine_core": "feature~fix_identity_usage_upon_process_termination",
     "@process-engine/persistence_api.repositories.sequelize": "~1.1.0",
     "@process-engine/persistence_api.services": "~1.1.0",
     "@process-engine/persistence_api.use_cases": "~1.1.0",


### PR DESCRIPTION
## Changes

Use a requesting users identity to terminate a ProcessInstance.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/474

PR: #212

## How to test the changes

Run the tests.